### PR TITLE
Fix php 8.4 compatibility

### DIFF
--- a/lib/IgraalOSL/StatsTable/Dumper/CSV/CSVDumper.php
+++ b/lib/IgraalOSL/StatsTable/Dumper/CSV/CSVDumper.php
@@ -61,7 +61,7 @@ class CSVDumper extends Dumper
                 $line[$index] = $this->formatValue($format, $line[$index]);
             }
         }
-        fputcsv($fileHandler, $line, $this->delimiter, $this->enclosure);
+        fputcsv($fileHandler, $line, $this->delimiter, $this->enclosure, "\\");
     }
 
     public function getMimeType()

--- a/lib/IgraalOSL/StatsTable/StatsColumnBuilder.php
+++ b/lib/IgraalOSL/StatsTable/StatsColumnBuilder.php
@@ -10,9 +10,9 @@ class StatsColumnBuilder
      * @param array                $values      Associative array like index => { name => value }
      * @param string               $headerName  Header name
      * @param string               $format      Format
-     * @param AggregationInterface $aggregation Aggregation
+     * @param AggregationInterface|null $aggregation Aggregation
      */
-    public function __construct($values, $headerName = '', $format = null, AggregationInterface $aggregation = null, $metaData = [])
+    public function __construct($values, $headerName = '', $format = null, ?AggregationInterface $aggregation = null, $metaData = [])
     {
         $this->values = $values;
         $this->headerName = $headerName;

--- a/lib/IgraalOSL/StatsTable/StatsTableBuilder.php
+++ b/lib/IgraalOSL/StatsTable/StatsTableBuilder.php
@@ -57,9 +57,9 @@ class StatsTableBuilder
      * @param $columnName
      * @param null $headerName
      * @param null $format
-     * @param AggregationInterface $aggregation
+     * @param AggregationInterface|null $aggregation
      */
-    public function addIndexesAsColumn($columnName, $headerName = null, $format = null, AggregationInterface $aggregation = null, $metaData = [])
+    public function addIndexesAsColumn($columnName, $headerName = null, $format = null, ?AggregationInterface $aggregation = null, $metaData = [])
     {
         $values = [];
         foreach ($this->indexes as $index) {
@@ -189,9 +189,9 @@ class StatsTableBuilder
      * @param DynamicColumnBuilderInterface $dynamicColumn
      * @param string                        $header
      * @param string                        $format
-     * @param AggregationInterface          $aggregation
+     * @param AggregationInterface|null     $aggregation
      */
-    public function addDynamicColumn($columnName, DynamicColumnBuilderInterface $dynamicColumn, $header = '', $format = null, AggregationInterface $aggregation = null, $metaData = [])
+    public function addDynamicColumn($columnName, DynamicColumnBuilderInterface $dynamicColumn, $header = '', $format = null, ?AggregationInterface $aggregation = null, $metaData = [])
     {
         $values = $dynamicColumn->buildColumnValues($this);
         $this->columns[$columnName] = new StatsColumnBuilder($values, $header, $format, $aggregation, $metaData);
@@ -203,9 +203,9 @@ class StatsTableBuilder
      * @param array                         $values
      * @param string                        $header
      * @param string                        $format
-     * @param AggregationInterface          $aggregation
+     * @param AggregationInterface|null     $aggregation
      */
-    public function addColumn($columnName, array $values, $header = '', $format = null, AggregationInterface $aggregation = null, $metaData = [])
+    public function addColumn($columnName, array $values, $header = '', $format = null, ?AggregationInterface $aggregation = null, $metaData = [])
     {
         $this->columns[$columnName] = new StatsColumnBuilder($values, $header, $format, $aggregation, $metaData);
     }


### PR DESCRIPTION
- Implicitly marking parameter $aggregation as nullable is deprecated, the explicit nullable type must be used instead
- Deprecated: fputcsv(): the $escape parameter must be provided as its default value will change