### PR TITLE
Cleanup code

### DIFF
--- a/lib/IgraalOSL/StatsTable/StatsTable.php
+++ b/lib/IgraalOSL/StatsTable/StatsTable.php
@@ -131,7 +131,7 @@ class StatsTable
      */
     protected function removeColumnsInLine(array &$line, array $columnsMap)
     {
-        foreach ($line as $k => $v) {
+        foreach (array_keys($line) as $k) {
             if (array_key_exists($k, $columnsMap)) {
                 unset($line[$k]);
             }
@@ -181,13 +181,12 @@ class StatsTable
 
     /**
      * Sort stats table by multiple column with a custom compare function
-     * @param $columns $columns Associative array : KEY=> column name (string), VALUE=> Custom function (function)
+     * @param array $columns Associative array : KEY=> column name (string), VALUE=> Custom function (function)
      * @return $this
      */
     public function uSortMultipleColumn($columns)
     {
-        $dataFormats = $this->dataFormats;
-        $sort = function ($a, $b) use ($columns, $dataFormats) {
+        $sort = function ($a, $b) use ($columns) {
             foreach ($columns as $colName => $fn) {
                 $tmp = $fn($a[$colName], $b[$colName]);
                 if ($tmp !== 0) {


### PR DESCRIPTION
K:\dev\github\php-stats-table\lib\IgraalOSL\StatsTable\StatsTable.php:
  134:33  hint    Symbol '$v' is declared but not used. ​intelephense(P1003)
  189:9   hint    Symbol '$dataFormats' is declared but not used. ​intelephense(P1003)
  190:50  hint    Symbol '$dataFormats' is declared but not used. ​intelephense(P1003)
  191:22  error   Expected type 'iterable|object'. Found '$columns'. ​intelephense(P1006)